### PR TITLE
feat: add semver option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ This section is just to document the environment variables used by the plugin. A
 
 ### Options
 
-As of now, there are no options.
+| Option   | Description                                                  | Type      | Default Value |
+| -------- | ------------------------------------------------------------ | --------- | ------------- |
+| `semver` | Publish only a valid semantic version number. Example: 1.1.1 | `boolean` | `false`       |
 
 ## Contributing
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -5,7 +5,7 @@ const SemanticReleaseError = require('@semantic-release/error');
 
 const CONTENT_TYPE = 'application/vnd.docker.distribution.manifest.v2+json';
 
-const getVersionTags = function (version) {
+const getVersionTags = function (version, isSemver) {
   const major = semver.major(version);
   const minor = semver.minor(version);
   const patch = semver.patch(version);
@@ -13,6 +13,9 @@ const getVersionTags = function (version) {
     ? `-${semver.prerelease(version).join('.')}`
     : '';
 
+  if (isSemver) {
+    return [`${major}.${minor}.${patch}${prerelease}`];
+  }
   return [
     `${major}.${minor}.${patch}${prerelease}`,
     `${major}.${minor}${prerelease}`,
@@ -73,7 +76,7 @@ module.exports = async (pluginConfig, context) => {
 
   const url = `https://${CI_REGISTRY}/v2/${CI_PROJECT_PATH}/manifests/`;
   const manifest = await getManifest(`${url}/${commit}`, Authorization);
-  const nextVersions = getVersionTags(version);
+  const nextVersions = getVersionTags(version, pluginConfig.semver ?? false);
   nextVersions.forEach(async (item) => {
     // eslint-disable-next-line no-unused-vars
     const result = await pushTag(`${url}/${item}`, Authorization, manifest);


### PR DESCRIPTION
Fixes: #18 
Adds the semver option to only publish a valid semantic version number.